### PR TITLE
Document release-based naming of services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,0 @@
-/blue/*
-!/blue/config/
-/blue/config/*
-!/blue/config/teamscale.properties
-
-/green/*
-!/green/config/
-/green/config/*
-!/green/config/teamscale.properties

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Teamscale Docker Deployment
 
-This repository contains a reference configuration for deploying Teamscale using *docker-compose*.
+This repository contains a reference configuration for deploying Teamscale using [*docker-compose*](https://docs.docker.com/compose/).
 
-It follows the pattern of a [blue-green deployment](https://en.wikipedia.org/wiki/Blue-green_deployment) strategy:
-It contains two Teamscale instances, called "blue" and "green", that alternate between being the production server and the staging environment.
-In addition an *nginx* reverse proxy in front of these terminates SSL and allows zero-downtime switches between the instances.
+In contrast to the simple setup described in the [Teamscale Docker How-To](https://docs.teamscale.com/howto/installing-teamscale/installing-with-docker/) this setup describes a more complex setup with multiple Teamscale instances used for staging and a reverse proxy for SSL termination.
+Focus is put on switching the production instance with zero downtime.
 
-Although this repository will give you a good starting point in setting up Teamscale, we strongly recommend reading the following documentation:
+Although this repository will give you a good starting point in setting up Teamscale, we strongly recommend reading the following documentation first:
 * [How to install Teamscale with Docker and docker-compose](https://docs.teamscale.com/howto/installing-with-docker/)
 * [How to access Teamscale via a Reverse Proxy](https://docs.teamscale.com/howto/configuring-reverse-proxy/)
 
-In particular, before starting to configure a deployment with multiple Teamscale instances, set up a _single_ first using [the Docker installation guide](https://docs.teamscale.com/howto/installing-with-docker/).
+In particular, before starting to configure a deployment with multiple Teamscale instances, set up a _single_ instance first.
 It is much easier to address infrastructure and configuration problems when dealing with a simple one-instance setup.
+Please refer to the according section in the [official documentation](https://docs.teamscale.com/howto/installing-with-docker/) and the [specific section](#single-instance) in this guide.
 
 ## Installation
 
@@ -20,110 +20,164 @@ It is much easier to address infrastructure and configuration problems when deal
 The whole deployment setup can be executed locally as follows, given `docker` and `docker-compose` are installed:
 
 1. [Download](https://github.com/cqse/teamscale-docker-deployment/archive/refs/heads/master.zip) the contents of this repository as a zip file and extract it.
+
 2. Start the containers using `sudo ./start.sh`.
    This starts all containers in detached mode (`docker-compose up -d`), reloads the nginx config (`./nginx-reload.sh`) and then follows the logs `docker-compose logs --follow`.
-3. The servers should be available using
-  - <https://teamscale.localhost> (blue, the productive server)
-  - <https://teamscale-staging.localhost> (green, the staging server)
+
+   _Note:_ You can detach from the console at any time using `Ctrl+C`.
+
+3. The Teamscale servers should be available via NGINX at the following URLs
+  - <https://teamscale.localhost> (the production server)
+  - <https://teamscale-staging.localhost> (the staging server)
 
 ### Production Setup
 
-If you are migrating from a previous setup, e.g. from setting up a first independent instance, copy all config files and the `storage` folder to `./blue`.
-  The *blue* instance will be the new production instance.
+#### Motivation
 
-- Ensure a valid [Teamscale license file](https://docs.teamscale.com/getting-started/installing-teamscale/#getting-your-evaluation-license) is placed in the config directories, e.g. `./blue/config/teamscale.license`.
+You may ask, why do I need to deploy two Teamscale instances for updates at all?
+The reason is that Teamscale does not perform database upgrades upon updating from one feature version to another (e.g. v7.7 to v7.8).
+Instead it performs a fresh analysis of source code and other artifacts to compensate for newly added or modified analyses.
+Ideally this reanalysis is performed on a second instance to avoid unavailability of analysis results.
+Patch releases, however, (e.g. v7.7.1 to v7.7.2) are drop-in and thus do _not_ require setting up a staging instance .
+For more information, please consult the corresponding how-to on [updating Teamscale](https://docs.teamscale.com/howto/updating-teamscale/#feature-version-updates).
+
+#### Architecture
+
+Instead of hard-coding two instances, e.g. named `production` and `staging`, this guides follows a Teamscale release-based deployment setup.
+It configures Teamscale services according to releases and has the advantage of documenting the the version in paths and service names.
+Thus, it may prevent you from "mixing up" instances and allows to switch the production server without downtime.
+It comes, however, with increased effort of creating folders and copying files for each release.
+
+This example describes two Teamscale instances:
+* `v7.7` is the production instance: in a real-world scenario, this instance would already be filled with analysis data)
+* `v7.8` is the staging instance: in a real-world scenario, this instance would reanalyze the data of `v7.7` and go live after the analysis has finished)
+
+The servers should be available using
+  - <https://teamscale.localhost> (7.7, the production server)
+  - <https://teamscale-next.localhost> (7.8, the staging server)
+
+The data and configuration files for these instances are stored in folders named according to the deployed releases, e.g. `v7.7` and `v7.8`.
+Also the services described in `docker-compose.yml` have the same naming scheme, e.g. `v7.7` and `v7.8`.
+
+#### Getting started
+
+_Note:_ `v7.7` and `v7.8` are only used as example, please replace these with your current needs.
+Especially when migrating from a previous setup like setting up a first independent instance, copy all config files and the `storage` folder to e.g. `./v7.7`.
+
+- Ensure a valid [Teamscale license file](https://docs.teamscale.com/getting-started/installing-teamscale/#getting-your-evaluation-license) is placed in the config directories, e.g. `./v7.7/config/teamscale.license`.
 - Adjust [deploy-time configuration](https://docs.teamscale.com/reference/administration-ts-installation/#configuring-teamscale) such as the amount of workers (`engine.workers` in `teamscale.properties`) and memory (`TEAMSCALE_MEMORY` in `docker-compose.yml`).
 - Change the `server_name`s in `./nginx/teamscale.conf` to the production domains and replace the self-signed certificates in `./nginx` by valid ones matching this domain.
-- Enable [automatic backups](https://docs.teamscale.com/howto/handling-backups/#automated-backups) (Starting with Teamscale 7.8 backups are enabled by default).
+- Enable [automatic backups](https://docs.teamscale.com/howto/handling-backups/#automated-backups) (Starting with Teamscale v7.8 backups are enabled by default).
 - Make sure Docker and the services are automatically restarted when you restart your server.
 
-### Switching instances
+_Note:_ For initial setup you may want to just run a [single instance](#single-instance).
+
+#### Prepare for a new release
 
 Besides providing a smooth starting point to deploy Teamscale using Docker, the setup described allows to switch instances without downtime.
 
-You can prepare lengthy updates and reanalyses in the *staging* instance that is available via `https://teamscale-staging.localhost`.
-Once you are satisfied with the changes in the staging instance edit `./nginx/teamscale.conf` and switch the `blue` and `green` values of variables `$teamscale_prod` and `$teamscale_next`.
-After saving the file simply execute `sudo ./nginx-reload.sh` (or `sudo ./start.sh` as it reloads the configuration and ensures all containers are started).
-You should now be able to access the previous *staging* instance using `https://teamscale.localhost`.
+Once you want to update to a new Teamscale release, e.g. `v7.8`, the following steps are required:
+
+1. Add a new directory named according to the version, e.g. `v7.8`.
+  - copy the `config` folder (containing `teamscale.license` and `teamscale.properties` ) from the production instance to `v7.8`
+  - adjust any configuration (e.g. workers, memory)
+
+2. Add a new service entry in `docker-compose.yml`, e.g. by coping the entry from `v7.7`
+  - adjust the `image` to the new release, e.g. `cqse/teamscale:7.8.latest`
+  - change the volume mount to the newly created folder, e.g. `./v7.8/:/var/teamscale/`
+
+3. Reference the `v7.8` Docker service in the staging server section of `nginx/teamscale.conf` (`set $teamscale_next  v7.8;`)
+
+Executing `sudo ./start.sh` will pull the images, start the Teamscale service and update nginx.
+
+#### Switch to a new release
+
+Once the new release has finished analysis, it can be set as productive instance without downtime as follows:
+
+1. Update the production server section of `nginx/teamscale.conf` to reference the previous staging Teamscale server (e,g. `set $teamscale_prod  v7.8;`)
+
+2. Reload the nginx configuration by executing `sudo ./nginx-reload.sh`
 
 ## Further tweaks and considerations
 
-### Name services according to releases
+### Single instance
 
-Instead of alternating and reusing two instances a different deployment method is naming Teamscale services according to releases.
-This has the advantage of documenting the the version in paths and service names.
-Thus it may prevent you from "mixing up" the colors green and blue when switching instances.
-It comes, however, with increased effort of creating folders and copying files for each release.
+The staging instance (in this example `v7.8`) can be disabled in `docker-compose.yml` for the initial setup, e.g. by renaming the service from `v7.8` to `x-v7.8`.
+Prefixing a service with `x-` [hides](https://docs.docker.com/compose/compose-file/#extension) it from _docker-compose_.
 
-The Teamscale services in `docker-compose.yml` might look similar to this snippet:
+If you want to use this setup to run exactly one instance this service can be removed completely.
+In addition, you should delete the staging server in the `teamscale.conf` nginx configuration.
 
-```yaml
-  # Teamscale 7.7
-  v77:
-    image: 'cqse/teamscale:7.7.0'
+### Blue-Green deployment
+
+A different deployment pattern is the so-called [blue-green deployment](https://en.wikipedia.org/wiki/Blue-green_deployment) strategy:
+It contains two Teamscale instances, called "blue" and "green", that alternate between being the production server and the staging environment.
+
+The setup is similar to the release-based naming but relieves you from creating/copying new services and configuration files for each release.
+It contains two `docker-compose` services named `blue` and `green` with data and configuration directories named accordingly:
+
+```yml
+  blue:
+    image: 'cqse/teamscale:7.7.latest'
     restart: unless-stopped
     working_dir: /var/teamscale
     volumes:
-      - ./v77/:/var/teamscale/
+      - ./blue/:/var/teamscale/
 
-  # Teamscale 7.8
-  v78:
-    image: 'cqse/teamscale:7.8.0'
+  green:
+    image: 'cqse/teamscale:7.8.latest'
     restart: unless-stopped
     working_dir: /var/teamscale
     volumes:
-      - ./v78/:/var/teamscale/
+      - ./green/:/var/teamscale/
 ```
 
-The nginx configuration (`nginx/teamscale.conf`) will look similar to the following snippet given version 7.7 should be used for production:
-
+The nginx configuration `teamscale.conf` will look as follows if `blue` is the production server:
 
 ```nginx
-# Teamscale 7.7 Server
+# The production server (live)
 server {
-    set $teamscale_host  v77;
+    # Binds the production server to the "blue" docker container
+    set $teamscale_prod  blue;
 
-    server_name teamscale.localhost teamscale-v77.localhost;
+    server_name teamscale.localhost;
 
     listen      443  ssl http2;
     listen [::]:443  ssl http2;
 
     location / {
-        proxy_pass http://$teamscale_host:8080;
+        proxy_pass http://$teamscale_prod:8080;
     }
 }
 
-# Teamscale 7.8 Server
+# The staging server (next)
 server {
-    set $teamscale_host  v78;
+    # Binds the staging server to the "green" docker container
+    set $teamscale_next  green;
 
-    server_name teamscale-v78.localhost;
+    server_name teamscale-next.localhost;
 
     listen      443  ssl http2;
     listen [::]:443  ssl http2;
 
     location / {
-        proxy_pass http://$teamscale_host:8080;
+        proxy_pass http://$teamscale_next:8080;
     }
 }
 ```
 
-The servers should be available using
-  - <https://teamscale.localhost> (7.7, the productive server)
-  - <https://teamscale-v77.localhost> (7.7, the productive server, alternative address)
-  - <https://teamscale-v78.localhost> (7.8, the staging server)
+Preparation of a new deployment follows the same principle as described above in the release-based deployment.
+Once you are satisfied with the changes in the staging instance just edit `./nginx/teamscale.conf` and switch the `blue` and `green` values of variables `$teamscale_prod` and `$teamscale_next`.
+After saving the file simply execute `sudo ./nginx-reload.sh` (or `sudo ./start.sh` as it reloads the configuration and ensures all containers are started).
+You should now be able to access the previous *staging* instance using <https://teamscale.localhost>.
 
-Setting version 7.8 as productive instance just requires to move `teamscale.localhost` from one `server_name` to the other.
-
-Adding a new release requires to:
-- copy the `config` folder from an existing instance
-- add a new service entry in `docker-compose.yml`
-- add a new server in `nginx/teamscale.conf`
+The downside of this deployment strategy is that you need to be careful when making configuration changes or plan a new deployment not to "mix up" the colors blue and green.
+This especially is the case when you need to purge the storage directory when setting up a fresh instance.
 
 ### Visually distinguish both instances
 
-Set the `instance.name` property to `blue` or `green` respectively in each instance's `teamscale.properties` config file.
-This allows you to easily differentiate the blue and green environment from the Web UI.
+Set the `instance.name` property to the release number (e.g. `v7.7`, or `blue` and `green`) respectively in each instance's `teamscale.properties` config file.
+This allows you to easily differentiate the environment from the Web UI.
 
 ### Using YAML anchors
 
@@ -136,7 +190,7 @@ x-teamscale-common: &teamscale-common
   environment:
     JAVA_OPTS: "-Dlog4j2.formatMsgNoLookups=true"
 
-  blue:
+  v7.7:
     <<: *teamscale-common
 ```
 
@@ -163,7 +217,7 @@ In particular change the mount from `/etc/nginx/conf.d/` to `/etc/nginx/` and pr
 If you need to access the HTTP interface of the container directly, e.g. for debugging reasons, you need to explicitly map the port:
 
 ```yaml
-  blue:
+  v7.7:
     # ...
     ports:
       - '8080:8080'
@@ -175,7 +229,7 @@ For Teamscale problems, the Teamscale logs will be stored in the folder `./logs`
 In addition, the console output is available via:
 
 ```sh
-sudo docker-compose logs <blue|green>
+sudo docker-compose logs <service-name>
 ```
 
 For nginx problems, consult the nginx logs:
@@ -189,15 +243,3 @@ sudo docker-compose logs nginx
 Please restart nginx by running `sudo docker-compose restart nginx`.
 Nginx noticed that the Teamscale instance was down (e.g. due to a restart) and is now refusing to try to reconnect to it.
 After restarting, it should be reachable again.
-
-### Bypass the reverse proxy
-
-In the default setup the Teamscale server can only be accessed using the reverse proxy.
-If you need to directly access the service, a port mapping to port `8080` has to be established:
-
-```yaml
-blue:
-  # ...
-  ports:
-      - '8080:8080'
-```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The whole deployment setup can be executed locally as follows, given `docker` an
 2. Start the containers using `sudo ./start.sh`.
    This starts all containers in detached mode (`docker-compose up -d`), reloads the nginx config (`./nginx-reload.sh`) and then follows the logs `docker-compose logs --follow`.
 
-   _Note:_ You can detach from the console at any time using `Ctrl+C`.
+   _Note:_ You can detach from the console at any time using `Ctrl+C`. Teamscale will keep running.
 
 3. The Teamscale servers should be available via NGINX at the following URLs
   - <https://teamscale.localhost> (the production server)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Thus, it may prevent you from "mixing up" instances and allows to switch the pro
 It comes, however, with increased effort of creating folders and copying files for each release.
 
 This example describes two Teamscale instances:
-* `v7.7` is the production instance: in a real-world scenario, this instance would already be filled with analysis data)
+* `v7.7` is the production instance: in a real-world scenario, this instance would already be filled with analysis data
 * `v7.8` is the staging instance: in a real-world scenario, this instance would reanalyze the data of `v7.7` and go live after the analysis has finished)
 
 The servers should be available using

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It comes, however, with increased effort of creating folders and copying files f
 
 This example describes two Teamscale instances:
 * `v7.7` is the production instance: in a real-world scenario, this instance would already be filled with analysis data
-* `v7.8` is the staging instance: in a real-world scenario, this instance would reanalyze the data of `v7.7` and go live after the analysis has finished)
+* `v7.8` is the staging instance: in a real-world scenario, this instance would reanalyze the data of `v7.7` and go live after the analysis has finished
 
 The servers should be available using
   - <https://teamscale.localhost> (7.7, the production server)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This has the advantage of documenting the the version in paths and service names
 Thus it may prevent you from "mixing up" the colors green and blue when switching instances.
 It comes, however, with increased effort of creating folders and copying files for each release.
 
-The Teamscale services in `docker-compose.yml` might look similar to this snipped:
+The Teamscale services in `docker-compose.yml` might look similar to this snippet:
 
 ```yaml
   # Teamscale 7.7
@@ -75,7 +75,7 @@ The Teamscale services in `docker-compose.yml` might look similar to this snippe
       - ./v78/:/var/teamscale/
 ```
 
-The nginx configuration (`nginx/teamscale.conf`) will look similar to the following snipped given version 7.7 should be used for production:
+The nginx configuration (`nginx/teamscale.conf`) will look similar to the following snippet given version 7.7 should be used for production:
 
 
 ```nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,28 +2,28 @@ version: '3'
 
 services:
 
-  # The first Teamscale instance.
-  blue:
-    image: 'cqse/teamscale:7.7.0'
+  # The production Teamscale instance.
+  v7.7:
+    # This targets the latest 7.7 release. Altenatively use e.g. 'cqse/teamscale:7.7.0' to point to a specific release.
+    image: 'cqse/teamscale:7.7.latest'
     restart: unless-stopped
     # The working directory within the docker container, where all data is stored.
     # This is different from the installation directory `/opt/teamscale`
     working_dir: /var/teamscale
     volumes:
-      # Use the `blue` folder as working directory
-      - ./blue/:/var/teamscale/
+      # Use the `v7.7` folder as working directory
+      - ./v7.7/:/var/teamscale/
     environment:
       # The Teamscale memory limit (alternative to store in jvm.properties)
       TEAMSCALE_MEMORY: 4G
 
-  # The second Teamscale instance, usually with another version.
-  green:
-    image: 'cqse/teamscale:7.7.0'
+  # The staging Teamscale instance.
+  v7.8:
+    image: 'cqse/teamscale:7.8.0rc3'
     restart: unless-stopped
     working_dir: /var/teamscale
     volumes:
-      # Use the `green` folder as working directory
-      - ./green/:/var/teamscale/
+      - ./v7.8/:/var/teamscale/
     environment:
       TEAMSCALE_MEMORY: 4G
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   # The staging Teamscale instance.
   v7.8:
-    image: 'cqse/teamscale:7.8.0rc3'
+    image: 'cqse/teamscale:7.8.latest'
     restart: unless-stopped
     working_dir: /var/teamscale
     volumes:

--- a/nginx/teamscale.conf
+++ b/nginx/teamscale.conf
@@ -1,8 +1,8 @@
 
 # The production server (live)
 server {
-    # Binds the production server to the "blue" docker container
-    set $teamscale_prod  blue;
+    # Binds the production server to the "v7.7" docker container
+    set $teamscale_prod  v7.7;
 
     server_name teamscale.localhost;
 
@@ -17,8 +17,8 @@ server {
 
 # The staging server (next)
 server {
-    # Binds the staging server to the "green" docker container
-    set $teamscale_next  green;
+    # Binds the staging server to the "v7.8" docker container
+    set $teamscale_next  v7.8;
 
     server_name teamscale-next.localhost;
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-docker-compose up --remove-orphans --wait --detach $@
+docker-compose up --remove-orphans --detach $@
 ./nginx-reload.sh
-docker-compose logs --follow --tail=1000
+docker-compose logs --follow --tail=100

--- a/v7.7/.gitignore
+++ b/v7.7/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!config

--- a/v7.7/config/teamscale.properties
+++ b/v7.7/config/teamscale.properties
@@ -11,10 +11,10 @@ engine.workers=2
 # server.urlprefix=teamscale
 
 # The database type. One of rocksdb, leveldb, cassandra, or memory (in-memory database, only for development). Please note that this is an expert option.
-# database.type=leveldb
+database.type=leveldb
 
 # The directory used by the storage system, defaults to 'storage' within the Teamscale installation directory
-database.directory=storage
+# database.directory=storage
 
 # The cache size used by the database in MB, defaults to 512
 # database.cache-size=

--- a/v7.7/config/teamscale.properties
+++ b/v7.7/config/teamscale.properties
@@ -2,7 +2,7 @@
 engine.workers=2
 
 # The identifying name of the Teamscale instance.
-# instance.name=green
+# instance.name=v7.7
 
 # The server port for HTTP, defaults to 8080. When using HTTPS, this may be set to 0 for disabling HTTP
 # server.port=8080
@@ -14,7 +14,7 @@ engine.workers=2
 # database.type=leveldb
 
 # The directory used by the storage system, defaults to 'storage' within the Teamscale installation directory
-# database.directory=storage
+database.directory=storage
 
 # The cache size used by the database in MB, defaults to 512
 # database.cache-size=

--- a/v7.8/.gitignore
+++ b/v7.8/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!config

--- a/v7.8/config/teamscale.properties
+++ b/v7.8/config/teamscale.properties
@@ -11,10 +11,10 @@ engine.workers=2
 # server.urlprefix=teamscale
 
 # The database type. One of rocksdb, leveldb, cassandra, or memory (in-memory database, only for development). Please note that this is an expert option.
-# database.type=leveldb
+database.type=leveldb
 
 # The directory used by the storage system, defaults to 'storage' within the Teamscale installation directory
-database.directory=storage
+# database.directory=storage
 
 # The cache size used by the database in MB, defaults to 512
 # database.cache-size=

--- a/v7.8/config/teamscale.properties
+++ b/v7.8/config/teamscale.properties
@@ -2,7 +2,7 @@
 engine.workers=2
 
 # The identifying name of the Teamscale instance.
-# instance.name=blue
+# instance.name=v7.8
 
 # The server port for HTTP, defaults to 8080. When using HTTPS, this may be set to 0 for disabling HTTP
 # server.port=8080
@@ -14,7 +14,7 @@ engine.workers=2
 # database.type=leveldb
 
 # The directory used by the storage system, defaults to 'storage' within the Teamscale installation directory
-# database.directory=storage
+database.directory=storage
 
 # The cache size used by the database in MB, defaults to 512
 # database.cache-size=


### PR DESCRIPTION
Documents an alternative deployment approach using release version based naming of Teamscale services.

This is how we currently handle naming of cloud instances and I could also consider making this the default instead of the more abstract concepts blue/green. But for now I just want to at least document.